### PR TITLE
updated for pimcore 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ In addition it offers two additional features:
 
 * Apply everything at once
 * Show/Hide fields that are equal (defaults to hide)
+
+
+## Running with Pimcore < 5.4
+With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work 
+with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
+```
+    # rewrite rule for pre pimcore 5.4 core static files
+    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
+``` 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "sort-packages": true
   },
   "require": {
-    "pimcore/core-version": ">=5.2.0 <5.4"
+    "pimcore/core-version": ">=5.2.0 <5.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/Resources/public/css/icons.css
+++ b/src/Resources/public/css/icons.css
@@ -3,7 +3,7 @@
 }
 
 .plugin_objectmerger_icon_revert  {
-    background: url(/pimcore/static6/img/flat-color-icons/undo.svg) left center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/undo.svg) left center no-repeat !important;
 }
 
 .plugin_objectmerger_icon_gray_arrow  {
@@ -15,7 +15,7 @@
 }
 
 .plugin_objectmerger_icon_lock  {
-    background: url(/pimcore/static6/img/icon/lock.png) left center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/icon/lock.png) left center no-repeat !important;
 }
 
 .plugin_objectmerger_icon_advanced  {

--- a/src/Resources/public/js/grideditor.js
+++ b/src/Resources/public/js/grideditor.js
@@ -109,7 +109,7 @@ pimcore.plugin.objectmerger.grideditor = Class.create({
             items: [
                 {
                     tooltip: t('up'),
-                    icon: "/pimcore/static6/img/flat-color-icons/up.svg",
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/up.svg",
                     handler: function (grid, rowIndex) {
                         if (rowIndex > 0) {
                             var store = grid.getStore();
@@ -133,7 +133,7 @@ pimcore.plugin.objectmerger.grideditor = Class.create({
             items: [
                 {
                     tooltip: t('down'),
-                    icon: "/pimcore/static6/img/flat-color-icons/down.svg",
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/down.svg",
                     handler: function (grid, rowIndex) {
                         if (rowIndex < (grid.getStore().getCount() - 1)) {
                             var store = grid.getStore();

--- a/src/Resources/public/js/plugin.js
+++ b/src/Resources/public/js/plugin.js
@@ -119,7 +119,7 @@ pimcore.plugin.objectmerger = Class.create(pimcore.plugin.admin,{
             },{
                 xtype: "button",
                 text: t("plugin_objectmerger_btn_compare"),
-                icon: "/pimcore/static6/img/icon/tick.png",
+                icon: "/bundles/pimcoreadmin/img/icon/tick.png",
                 handler: function () {
                     Ext.Ajax.request({
                         url: "/admin/elementsobjectmerger/admin/getid",


### PR DESCRIPTION
## Running with Pimcore < 5.4
With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
```
    # rewrite rule for pre pimcore 5.4 core static files
    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
``` 