### PR TITLE
Fix: Cannot read properties of undefined (reading 'add')

### DIFF
--- a/src/Resources/public/js/plugin.js
+++ b/src/Resources/public/js/plugin.js
@@ -32,12 +32,13 @@ pimcore.plugin.objectmerger = Class.create(pimcore.plugin.admin,{
     pimcoreReady: function (params,broker) {
         var extrasMenu = pimcore.globalmanager.get("layout_toolbar").extrasMenu;
 
-        extrasMenu.add({
-            text: t("plugin_objectmerger_compare"),
-            iconCls: "plugin_objectmerger_nav_icon_compare",
-            handler:  this.showObjectSelectionDialog.bind(this)
-
-        });
+        if (extrasMenu) {
+            extrasMenu.add({
+                text: t("plugin_objectmerger_compare"),
+                iconCls: "plugin_objectmerger_nav_icon_compare",
+                handler:  this.showObjectSelectionDialog.bind(this)
+            });
+        }
     },
 
 


### PR DESCRIPTION
If the user has no permission for the extras menu, it come to this error:
![image](https://user-images.githubusercontent.com/998558/175231416-96a0805e-1f35-4a7e-9821-1763c6ee4d94.png)
