### PR TITLE
[Task]: Add phpdoc param and return type hint, remove deprecated code

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -36,9 +36,9 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
     private $objectData;
 
     /**
-     * @param $object
-     * @param $key
-     * @param $fielddefinition Data
+     * @param Concrete $object
+     * @param int|string $key
+     * @param Data $fielddefinition
      */
     private function getDiffDataForField($object, $key, $fielddefinition)
     {
@@ -51,9 +51,6 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         }
     }
 
-    /**
-     * @param Concrete $object
-     */
     private function getDiffDataForObject(Concrete $object)
     {
         foreach ($object->getClass()->getFieldDefinitions() as $key => $def) {
@@ -104,8 +101,6 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
      * Generates a diff for the given two object ids.
      *
      * @Route("/diff")
-     *
-     * @param Request $request
      *
      * @return JsonResponse
      */
@@ -221,8 +216,6 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
      *
      * @Route("/getid")
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
     public function getidAction(Request $request)
@@ -248,8 +241,6 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
      * Saves the merged object.
      *
      * @Route("/save")
-     *
-     * @param Request $request
      *
      * @return JsonResponse
      */

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -51,13 +51,22 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         }
     }
 
-    private function getDiffDataForObject(Concrete $object, $objectFromVersion = false)
+    /**
+     * @param Concrete $object
+     */
+    private function getDiffDataForObject(Concrete $object)
     {
         foreach ($object->getClass()->getFieldDefinitions() as $key => $def) {
             $this->getDiffDataForField($object, $key, $def);
         }
     }
 
+    /**
+     * @param array $arr1
+     * @param array $arr2
+     *
+     * @return array
+     */
     public function combineKeys($arr1, $arr2)
     {
         $result = [];
@@ -72,7 +81,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
     }
 
     /**
-     * @param  Concrete $object
+     * @param Concrete $object
      *
      * @return Concrete
      */
@@ -105,37 +114,22 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
         $id1 = $request->get('id1');
         $id2 = $request->get('id2');
 
-//        if (Element_Editlock::isLocked($id2, "object")) {
-//            $this->_helper->json(array(
-//                "editlock" => Element_Editlock::getByElement($id2, "object")
-//            ));
-//        }
-
-//        Element_Editlock::lock($id1, "object");
-//        Element_Editlock::lock($id2, "object");
-
         $object1 = AbstractObject::getById(intval($id1));
         $object2 = AbstractObject::getById(intval($id2));
 
         // set the latest available version for editmode
-        $latestObject1 = $this->getLatestVersion($object1);
-        $latestObject2 = $this->getLatestVersion($object2);
-
-        // we need to know if the latest version is published or not (a version), because of lazy loaded fields in $this->getDataForObject()
-        $objectFromVersion1 = $latestObject1 === $object1 ? false : true;
-        $objectFromVersion2 = $latestObject1 === $object2 ? false : true;
-        $object1 = $latestObject1;
-        $object2 = $latestObject2;
+        $object1 = $this->getLatestVersion($object1);
+        $object2 = $this->getLatestVersion($object2);
 
         if ($object1->isAllowed('view') && $object2->isAllowed('view')) {
             $objectData = [];
 
-            $this->getDiffDataForObject($object1, $objectFromVersion1);
+            $this->getDiffDataForObject($object1);
 
             $dataFromObject1 = $this->objectData;
             $this->objectData = null;
 
-            $this->getDiffDataForObject($object2, $objectFromVersion2);
+            $this->getDiffDataForObject($object2);
             $dataFromObject2 = $this->objectData;
 
             $keys1 = array_keys($dataFromObject1);


### PR DESCRIPTION

The removal of bool `objectFromVersion` parameter should be safe from bc break because it's a private method.
Looks like some leftover from the changes [here ](https://github.com/pimcore/object-merger/compare/v.3.0.4...v.3.0.5)