### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "~8.3.0 || ~8.4.0",
-    "pimcore/pimcore": "^12.0"
+    "pimcore/pimcore": "^12.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.12.15"

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -12,6 +12,7 @@
 
 namespace Pimcore\Bundle\ObjectMergerBundle\Controller;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Controller\Traits\JsonHelperTrait;
 use Pimcore\Controller\UserAwareController;
 use Pimcore\Logger;
@@ -234,7 +235,7 @@ class AdminController extends UserAwareController
     #[Route('/save')]
     public function saveAction(Request $request): JsonResponse
     {
-        $objectId = $request->request->getInt('id');
+        $objectId = ParameterBagHelper::getInt($request->request, 'id');
 
         /**
          * @TODO Remove when removing support for Pimcore 10
@@ -256,7 +257,7 @@ class AdminController extends UserAwareController
 
         $preMergeEvent = new GenericEvent($this, [
             'targetId' => $object->getId(),
-            'sourceId' => $request->request->getInt('sourceId'),
+            'sourceId' => ParameterBagHelper::getInt($request->request, 'sourceId'),
         ]);
         $this->eventDispatcher->dispatch($preMergeEvent, 'plugin.ObjectMerger.preMerge');
 
@@ -286,11 +287,11 @@ class AdminController extends UserAwareController
 
         $postMergeEvent = new GenericEvent($this, [
             'targetId' => $object->getId(),
-            'sourceId' => $request->request->getInt('sourceId'),
+            'sourceId' => ParameterBagHelper::getInt($request->request, 'sourceId'),
         ]);
 
         $this->eventDispatcher->dispatch($postMergeEvent, 'plugin.ObjectMerger.postMerge');
 
-        return $this->jsonResponse(['success' => true, 'targetId' => $object->getId(), 'sourceId' => $request->request->getInt('sourceId')]);
+        return $this->jsonResponse(['success' => true, 'targetId' => $object->getId(), 'sourceId' => ParameterBagHelper::getInt($request->request, 'sourceId')]);
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -12,9 +12,9 @@
 
 namespace Pimcore\Bundle\ObjectMergerBundle\Controller;
 
-use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Controller\Traits\JsonHelperTrait;
 use Pimcore\Controller\UserAwareController;
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Logger;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;


### PR DESCRIPTION
This pull request refactors how integer parameters are retrieved from HTTP requests in the `AdminController`. The main change is to use the `ParameterBagHelper::getInt` method instead of the native Symfony `$request->request->getInt` method, which improves consistency and future-proofs the code for upcoming Pimcore versions.

Parameter handling improvements:

* Replaced all usages of `$request->request->getInt` with `ParameterBagHelper::getInt` for retrieving `id` and `sourceId` in the `saveAction` method in `AdminController.php`. [[1]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L237-R238) [[2]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L259-R260) [[3]](diffhunk://#diff-15f7f071121bfa3ffa4bf6f5b31db091f12a2ce65acae1642ab42c45e0c9eef7L289-R295)
* Added the `ParameterBagHelper` import to the top of `AdminController.php`.