### PR TITLE
3207 - [Object Merger] - Remove unnecessary quotes from translation YAML files

### DIFF
--- a/src/Resources/translations/studio.es.yaml
+++ b/src/Resources/translations/studio.es.yaml
@@ -2,12 +2,12 @@ compare_objects.empty: Sin valor
 compare_objects.nav.compare_objects: Comparar objetos
 compare_objects.title: Comparar objetos
 compare_objects.form.compare_btn: Comparar
-compare_objects.form.error.different_object_types: 'Los objetos seleccionados tienen tipos diferentes y no se pueden comparar.'
+compare_objects.form.error.different_object_types: Los objetos seleccionados tienen tipos diferentes y no se pueden comparar.
 compare_objects.toolbar.mirror_view: Vista espejo
 compare_objects.toolbar.apply_all: Aplicar todo
-compare_objects.toolbar.apply_all.description: 'Aplicar todo copia los valores de izquierda a derecha, actualizando solo los que son diferentes.'
+compare_objects.toolbar.apply_all.description: Aplicar todo copia los valores de izquierda a derecha, actualizando solo los que son diferentes.
 compare_objects.toolbar.reset: Restablecer cambios
 compare_objects.toolbar.save: Guardar
-compare_objects.initial_description: 'Seleccione dos objetos para comparar.'
+compare_objects.initial_description: Seleccione dos objetos para comparar.
 compare_objects.expand_unmodified_fields: Expandir todo
 compare_objects.no_difference: No hay diferencias entre las versiones seleccionadas

--- a/src/Resources/translations/studio.fr.yaml
+++ b/src/Resources/translations/studio.fr.yaml
@@ -2,12 +2,12 @@ compare_objects.empty: Aucune valeur
 compare_objects.nav.compare_objects: Comparer les objets
 compare_objects.title: Comparer les objets
 compare_objects.form.compare_btn: Comparer
-compare_objects.form.error.different_object_types: 'Les objets sélectionnés sont de types différents et ne peuvent pas être comparés.'
+compare_objects.form.error.different_object_types: Les objets sélectionnés sont de types différents et ne peuvent pas être comparés.
 compare_objects.toolbar.mirror_view: Vue miroir
 compare_objects.toolbar.apply_all: Tout appliquer
-compare_objects.toolbar.apply_all.description: 'Tout appliquer copie les valeurs de gauche à droite, en mettant à jour uniquement celles qui sont différentes.'
+compare_objects.toolbar.apply_all.description: Tout appliquer copie les valeurs de gauche à droite, en mettant à jour uniquement celles qui sont différentes.
 compare_objects.toolbar.reset: Réinitialiser les modifications
 compare_objects.toolbar.save: Enregistrer
-compare_objects.initial_description: 'Veuillez sélectionner deux objets à comparer.'
+compare_objects.initial_description: Veuillez sélectionner deux objets à comparer.
 compare_objects.expand_unmodified_fields: Tout déplier
 compare_objects.no_difference: 'Il n''y a aucune différence entre les versions sélectionnées'

--- a/src/Resources/translations/studio.it.yaml
+++ b/src/Resources/translations/studio.it.yaml
@@ -2,12 +2,12 @@ compare_objects.empty: Nessun valore
 compare_objects.nav.compare_objects: Confronta oggetti
 compare_objects.title: Confronta oggetti
 compare_objects.form.compare_btn: Confronta
-compare_objects.form.error.different_object_types: 'Gli oggetti selezionati hanno tipi diversi e non possono essere confrontati.'
+compare_objects.form.error.different_object_types: Gli oggetti selezionati hanno tipi diversi e non possono essere confrontati.
 compare_objects.toolbar.mirror_view: Vista speculare
 compare_objects.toolbar.apply_all: Applica tutto
-compare_objects.toolbar.apply_all.description: 'Applica tutto copia i valori da sinistra a destra, aggiornando solo quelli che sono diversi.'
+compare_objects.toolbar.apply_all.description: Applica tutto copia i valori da sinistra a destra, aggiornando solo quelli che sono diversi.
 compare_objects.toolbar.reset: Reimposta le modifiche
 compare_objects.toolbar.save: Salva
-compare_objects.initial_description: 'Selezionare due oggetti da confrontare.'
+compare_objects.initial_description: Selezionare due oggetti da confrontare.
 compare_objects.expand_unmodified_fields: Espandi tutto
 compare_objects.no_difference: Non ci sono differenze tra le versioni selezionate

--- a/src/Resources/translations/studio.no.yaml
+++ b/src/Resources/translations/studio.no.yaml
@@ -2,12 +2,12 @@ compare_objects.empty: Ingen verdi
 compare_objects.nav.compare_objects: Sammenlign objekter
 compare_objects.title: Sammenlign objekter
 compare_objects.form.compare_btn: Sammenlign
-compare_objects.form.error.different_object_types: 'De valgte objektene har forskjellige typer og kan ikke sammenlignes.'
+compare_objects.form.error.different_object_types: De valgte objektene har forskjellige typer og kan ikke sammenlignes.
 compare_objects.toolbar.mirror_view: Speilvend visning
 compare_objects.toolbar.apply_all: Bruk alle
-compare_objects.toolbar.apply_all.description: 'Bruk alle kopierer verdier fra venstre til høyre, og oppdaterer bare de som er forskjellige.'
+compare_objects.toolbar.apply_all.description: Bruk alle kopierer verdier fra venstre til høyre, og oppdaterer bare de som er forskjellige.
 compare_objects.toolbar.reset: Tilbakestill endringer
 compare_objects.toolbar.save: Lagre
-compare_objects.initial_description: 'Velg to objekter å sammenligne.'
+compare_objects.initial_description: Velg to objekter å sammenligne.
 compare_objects.expand_unmodified_fields: Utvid alle
 compare_objects.no_difference: Det er ingen forskjeller mellom de valgte versjonene

--- a/src/Resources/translations/studio.sv.yaml
+++ b/src/Resources/translations/studio.sv.yaml
@@ -2,12 +2,12 @@ compare_objects.empty: Inget värde
 compare_objects.nav.compare_objects: Jämför objekt
 compare_objects.title: Jämför objekt
 compare_objects.form.compare_btn: Jämför
-compare_objects.form.error.different_object_types: 'De valda objekten har olika typer och kan inte jämföras.'
+compare_objects.form.error.different_object_types: De valda objekten har olika typer och kan inte jämföras.
 compare_objects.toolbar.mirror_view: Spegelvänd vy
 compare_objects.toolbar.apply_all: Tillämpa alla
-compare_objects.toolbar.apply_all.description: 'Tillämpa alla kopierar värden från vänster till höger och uppdaterar bara de som är olika.'
+compare_objects.toolbar.apply_all.description: Tillämpa alla kopierar värden från vänster till höger och uppdaterar bara de som är olika.
 compare_objects.toolbar.reset: Återställ ändringar
 compare_objects.toolbar.save: Spara
-compare_objects.initial_description: 'Välj två objekt att jämföra.'
+compare_objects.initial_description: Välj två objekt att jämföra.
 compare_objects.expand_unmodified_fields: Expandera alla
 compare_objects.no_difference: Det finns inga skillnader mellan de valda versionerna


### PR DESCRIPTION
## Changes in this pull request
https://github.com/pimcore/studio-ui-bundle/issues/3207

Remove unnecessary quotes from translation YAML files. Only quotes required by YAML syntax are kept (interpolation placeholders, colons, special characters, boolean-like values, etc.).

## Additional info
- 15 unnecessary quotes removed across 5 files
- Validated with yaml.safe_load() — all values remain strings, no semantic changes