### PR TITLE
[Maintenance]: Add missing translations

### DIFF
--- a/src/Resources/translations/studio.de.yaml
+++ b/src/Resources/translations/studio.de.yaml
@@ -8,6 +8,7 @@ compare_objects.toolbar.apply_all: Alle übernehmen
 compare_objects.toolbar.apply_all.description: Alle übernehmen kopiert die Werte von links nach rechts und aktualisiert nur diejenigen, die sich unterscheiden.
 compare_objects.toolbar.reset: Änderungen zurücksetzen
 compare_objects.toolbar.save: Speichern
+compare_objects.toolbar.save.no_permission: Sie haben keine Berechtigung, dieses Objekt zu speichern.
 compare_objects.initial_description: Bitte wählen Sie zwei Objekte zum Vergleichen aus.
 compare_objects.expand_unmodified_fields: Alle aufklappen
 compare_objects.no_difference: Es gibt keinen Unterschied zwischen den ausgewählten Versionen

--- a/src/Resources/translations/studio.es.yaml
+++ b/src/Resources/translations/studio.es.yaml
@@ -8,6 +8,7 @@ compare_objects.toolbar.apply_all: Aplicar todo
 compare_objects.toolbar.apply_all.description: Aplicar todo copia los valores de izquierda a derecha, actualizando solo los que son diferentes.
 compare_objects.toolbar.reset: Restablecer cambios
 compare_objects.toolbar.save: Guardar
+compare_objects.toolbar.save.no_permission: No tiene permiso para guardar este objeto.
 compare_objects.initial_description: Seleccione dos objetos para comparar.
 compare_objects.expand_unmodified_fields: Expandir todo
 compare_objects.no_difference: No hay diferencias entre las versiones seleccionadas

--- a/src/Resources/translations/studio.fr.yaml
+++ b/src/Resources/translations/studio.fr.yaml
@@ -8,6 +8,7 @@ compare_objects.toolbar.apply_all: Tout appliquer
 compare_objects.toolbar.apply_all.description: Tout appliquer copie les valeurs de gauche à droite, en mettant à jour uniquement celles qui sont différentes.
 compare_objects.toolbar.reset: Réinitialiser les modifications
 compare_objects.toolbar.save: Enregistrer
+compare_objects.toolbar.save.no_permission: "Vous n'avez pas la permission d'enregistrer cet objet."
 compare_objects.initial_description: Veuillez sélectionner deux objets à comparer.
 compare_objects.expand_unmodified_fields: Tout déplier
 compare_objects.no_difference: 'Il n''y a aucune différence entre les versions sélectionnées'

--- a/src/Resources/translations/studio.it.yaml
+++ b/src/Resources/translations/studio.it.yaml
@@ -8,6 +8,7 @@ compare_objects.toolbar.apply_all: Applica tutto
 compare_objects.toolbar.apply_all.description: Applica tutto copia i valori da sinistra a destra, aggiornando solo quelli che sono diversi.
 compare_objects.toolbar.reset: Reimposta le modifiche
 compare_objects.toolbar.save: Salva
+compare_objects.toolbar.save.no_permission: Non si dispone dei permessi per salvare questo oggetto.
 compare_objects.initial_description: Selezionare due oggetti da confrontare.
 compare_objects.expand_unmodified_fields: Espandi tutto
 compare_objects.no_difference: Non ci sono differenze tra le versioni selezionate

--- a/src/Resources/translations/studio.no.yaml
+++ b/src/Resources/translations/studio.no.yaml
@@ -8,6 +8,7 @@ compare_objects.toolbar.apply_all: Bruk alle
 compare_objects.toolbar.apply_all.description: Bruk alle kopierer verdier fra venstre til høyre, og oppdaterer bare de som er forskjellige.
 compare_objects.toolbar.reset: Tilbakestill endringer
 compare_objects.toolbar.save: Lagre
+compare_objects.toolbar.save.no_permission: Du har ikke tillatelse til å lagre dette objektet.
 compare_objects.initial_description: Velg to objekter å sammenligne.
 compare_objects.expand_unmodified_fields: Utvid alle
 compare_objects.no_difference: Det er ingen forskjeller mellom de valgte versjonene

--- a/src/Resources/translations/studio.sv.yaml
+++ b/src/Resources/translations/studio.sv.yaml
@@ -8,6 +8,7 @@ compare_objects.toolbar.apply_all: Tillämpa alla
 compare_objects.toolbar.apply_all.description: Tillämpa alla kopierar värden från vänster till höger och uppdaterar bara de som är olika.
 compare_objects.toolbar.reset: Återställ ändringar
 compare_objects.toolbar.save: Spara
+compare_objects.toolbar.save.no_permission: Du har inte behörighet att spara detta objekt.
 compare_objects.initial_description: Välj två objekt att jämföra.
 compare_objects.expand_unmodified_fields: Expandera alla
 compare_objects.no_difference: Det finns inga skillnader mellan de valda versionerna


### PR DESCRIPTION
## Changes in this pull request

Add missing `compare_objects.toolbar.save.no_permission` translation key to all 6 language files (de, fr, it, es, sv, no).

This key was added to `studio.en.yaml` in #89 but the corresponding translations were not included.

## Keys added

| Language | Translation |
|----------|------------|
| DE | Sie haben keine Berechtigung, dieses Objekt zu speichern. |
| FR | Vous n'avez pas la permission d'enregistrer cet objet. |
| IT | Non si dispone dei permessi per salvare questo oggetto. |
| ES | No tiene permiso para guardar este objeto. |
| SV | Du har inte behörighet att spara detta objekt. |
| NO | Du har ikke tillatelse til å lagre dette objektet. |