### PR TITLE
[Symfony 8] Add central Symfony 8 compatibility check

### DIFF
--- a/.github/workflows/symfony8-compat.yaml
+++ b/.github/workflows/symfony8-compat.yaml
@@ -1,0 +1,10 @@
+name: "Symfony 8 compatibility"
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+jobs:
+  symfony8-compat:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main


### PR DESCRIPTION
## What

Adds `.github/workflows/symfony8-compat.yaml` — a thin caller for the central, reusable **Symfony 8
compatibility check**:

```yaml
uses: pimcore/workflows-collection-public/.github/workflows/reusable-symfony8-compat.yaml@main
```

**No source code is changed** — this repo already has **0** usages of the APIs the check bans.

## Why

Symfony 7.4 → 8 removes a number of APIs Pimcore uses. As each one is fixed across the platform, a rule is
added to the central check, and from then on **every** subscribed repo is guarded against it — no repo has
to maintain its own list, and a regression is caught on the PR that introduces it instead of during the
Symfony 8 bump.

Rules active today (both from Symfony 8.0, DependencyInjection):

| id | bans |
|---|---|
| `tagged-iterator-attribute` | `#[TaggedIterator(` — use `#[AutowireIterator]` |
| `tagged-iterator-import` | `use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;` |

Each rule is its own named check and annotates the offending line, so a red PR says exactly what to fix.
Verified for this repo before opening: **0** matches for either rule.

## Verification

The check runs on this PR itself, so a green `symfony8-compat` proves the wiring and the clean state in
one signal. The only file added is the workflow.

## Context

Step 1 of the Symfony 7.4 → 8 migration, from the readiness analysis of all 37 platform SBOM repos
(`pimcore/platform-version`, `migration-analysis/SUMMARY.md`). The central workflow was added in
pimcore/workflows-collection-public#154; 9 repos additionally needed the `#[TaggedIterator]` rename, which
is happening in parallel PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
